### PR TITLE
feat: Create Swift Package

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,3 +24,5 @@ jobs:
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
+    - name: Create Swift Package
+      run: ./gradlew createSwiftPackage

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -23,8 +23,7 @@ jobs:
     - name: Set up XCode
       uses: maxim-lobanov/setup-xcode@master
       with:
-        xcode-version: '12.2'
-        # xcode-version: latest-stable
+        xcode-version: '12.4'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,6 +20,11 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Set up XCode
+      uses: maxim-lobanov/setup-xcode@master
+        with:
+          xcode-version: '12.2'
+          # xcode-version: latest-stable
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,9 +22,9 @@ jobs:
         java-version: 1.8
     - name: Set up XCode
       uses: maxim-lobanov/setup-xcode@master
-        with:
-          xcode-version: '12.2'
-          # xcode-version: latest-stable
+      with:
+        xcode-version: '12.2'
+        # xcode-version: latest-stable
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ This command generates AAR files in `library/build/outputs/aar`:
 
 #### iOS
 
-TODO
+This command generates Swift package files in `common/swiftpackage` directory:
+
+``` 
+./gradlew createSwiftPackage
+```
 
 #### Desktop Java/Kotlin
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
         val iosMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-ios:$ktorVersion")
+                implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3-native-mt")
             }
         }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -61,7 +61,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-java:$ktorVersion")
-                implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.4.2")
+                implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-swing:$coroutineVersion")
             }
         }
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -57,6 +57,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-java:$ktorVersion")
+                implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-swing:$coroutineVersion")
             }
         }
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -51,7 +51,7 @@ kotlin {
         val iosMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-ios:$ktorVersion")
-                implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3-native-mt")
+                implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion-native-mt")
             }
         }
 

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -14,10 +14,6 @@ plugins {
 group = "edu.usf.cutr.otp"
 version = "1.0.0"
 
-repositories {
-    mavenLocal()
-}
-
 kotlin {
     android()
     jvm {

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -1,6 +1,6 @@
 
-val ktorVersion = "1.5.0"
-val coroutineVersion = "1.4.2"
+val ktorVersion = "1.5.3"
+val coroutineVersion = "1.4.3"
 
 plugins {
     kotlin("multiplatform")

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -57,7 +57,6 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-java:$ktorVersion")
-                implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-swing:$coroutineVersion")
             }
         }
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     id("com.android.library")
     id("kotlinx-serialization")
     id("kotlin-android-extensions")
+    id("com.chromaticnoise.multiplatform-swiftpackage") version "2.0.3"
 }
 
 kotlin {
@@ -69,3 +70,11 @@ val packForXcode by tasks.creating(Sync::class) {
     into(targetDir)
 }
 tasks.getByName("build").dependsOn(packForXcode)
+
+multiplatformSwiftPackage {
+    packageName("OpenTripPlannerClientLibrary")
+    swiftToolsVersion("5.3")
+    targetPlatforms {
+        iOS { v("13") }
+    }
+}

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -32,8 +32,11 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation("org.jetbrains.kotlin:kotlin-stdlib-common")
-                implementation(
-                    "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion")
+                implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion-native-mt") {
+                    version {
+                        strictly("$coroutineVersion-native-mt")
+                    }
+                }
                 implementation(
                     "org.jetbrains.kotlinx:kotlinx-serialization-json:1.1.0")
                 implementation("io.ktor:ktor-client-core:$ktorVersion")

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
     ios {
         binaries {
             framework {
-                baseName = "library"
+                baseName = "OpenTripPlannerClientLibrary"
             }
         }
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -51,7 +51,11 @@ kotlin {
         val iosMain by getting {
             dependencies {
                 implementation("io.ktor:ktor-client-ios:$ktorVersion")
-                implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion-native-mt")
+                implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion-native-mt") {
+                    version {
+                        strictly("$coroutineVersion-native-mt")
+                    }
+                }
             }
         }
 

--- a/library/src/iosMain/kotlin/edu/usf/cutr/otp/Dispatcher.kt
+++ b/library/src/iosMain/kotlin/edu/usf/cutr/otp/Dispatcher.kt
@@ -4,15 +4,9 @@ import kotlin.coroutines.*
 import kotlinx.coroutines.*
 import platform.darwin.*
 
-// 1
-internal actual val ApplicationDispatcher: CoroutineDispatcher =
-    NsQueueDispatcher(dispatch_get_main_queue())
+internal actual val ApplicationDispatcher: CoroutineDispatcher = NsQueueDispatcher(dispatch_get_main_queue())
 
-// 2
-internal class NsQueueDispatcher(
-    private val dispatchQueue: dispatch_queue_t
-) : CoroutineDispatcher() {
-
+internal class NsQueueDispatcher(private val dispatchQueue: dispatch_queue_t) : CoroutineDispatcher() {
     override fun dispatch(context: CoroutineContext, block: Runnable) {
         dispatch_async(dispatchQueue) {
             block.run()

--- a/library/src/iosMain/kotlin/edu/usf/cutr/otp/Dispatcher.kt
+++ b/library/src/iosMain/kotlin/edu/usf/cutr/otp/Dispatcher.kt
@@ -1,6 +1,21 @@
 package edu.usf.cutr.otp
 
-import kotlinx.coroutines.CoroutineDispatcher
+import kotlin.coroutines.*
+import kotlinx.coroutines.*
+import platform.darwin.*
 
+// 1
 internal actual val ApplicationDispatcher: CoroutineDispatcher =
     NsQueueDispatcher(dispatch_get_main_queue())
+
+// 2
+internal class NsQueueDispatcher(
+    private val dispatchQueue: dispatch_queue_t
+) : CoroutineDispatcher() {
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        dispatch_async(dispatchQueue) {
+            block.run()
+        }
+    }
+}


### PR DESCRIPTION
...when running:

`./gradlew createSwiftPackage`

This is an attempt to close https://github.com/CUTR-at-USF/opentripplanner-client-library/issues/7 by using the process discussed at https://johnoreilly.dev/posts/kotlinmultiplatform-swift-package/ to generate a Swift Package.

I can't test this on my local Windows machine but let's see if we can get it to work on CI.