### PR TITLE
feat: Add support for API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ planApi.getPlan(
 )
 ```
 
+You can set a URL parameter for an API key name and value (e.g., `plan?...&key=ABCD...`) if needed with:
+
+```kotlin
+...
+planApi = PlanApi(...)
+planApi.apiKey("key", "ABCD")
+planApi.getPlan(
+...
+```
+
 #### Bike Rental API
 
 ```kotlin

--- a/library/src/commonMain/kotlin/edu/usf/cutr/otp/Api.kt
+++ b/library/src/commonMain/kotlin/edu/usf/cutr/otp/Api.kt
@@ -34,7 +34,7 @@ abstract class Api {
      * @name name of the API key in the URL parameter
      * @value value of the API key in the URL parameter
      */
-    fun setApiKey(name: String, value: String) {
+    fun apiKey(name: String, value: String) {
         apiKeyName = name
         apiKeyValue = value
     }

--- a/library/src/commonMain/kotlin/edu/usf/cutr/otp/Api.kt
+++ b/library/src/commonMain/kotlin/edu/usf/cutr/otp/Api.kt
@@ -16,13 +16,8 @@
 
 package edu.usf.cutr.otp
 
-import io.ktor.client.*
-import io.ktor.client.request.*
-import io.ktor.http.*
-
 /**
- * Manager Class to make HTTP requests to the OTP Bike Rental API
- * @param url - Full URL to Bike Rental Information, Ex: "https://10.0.2.2:8080/otp/routers/default/bike_rental"
+ * Abstract class that holds information common to all API request types
  */
 
 abstract class Api {

--- a/library/src/commonMain/kotlin/edu/usf/cutr/otp/Api.kt
+++ b/library/src/commonMain/kotlin/edu/usf/cutr/otp/Api.kt
@@ -1,0 +1,41 @@
+/*
+   Copyright University of South Florida 2021
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+package edu.usf.cutr.otp
+
+import io.ktor.client.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+
+/**
+ * Manager Class to make HTTP requests to the OTP Bike Rental API
+ * @param url - Full URL to Bike Rental Information, Ex: "https://10.0.2.2:8080/otp/routers/default/bike_rental"
+ */
+
+abstract class Api {
+    internal var apiKeyName: String = ""
+    internal var apiKeyValue: String = ""
+
+    /**
+     * Sets the API key if needed to make the request
+     * @name name of the API key in the URL parameter
+     * @value value of the API key in the URL parameter
+     */
+    fun setApiKey(name: String, value: String) {
+        apiKeyName = name
+        apiKeyValue = value
+    }
+}

--- a/library/src/commonMain/kotlin/edu/usf/cutr/otp/bike_rental/api/BikeRentalApi.kt
+++ b/library/src/commonMain/kotlin/edu/usf/cutr/otp/bike_rental/api/BikeRentalApi.kt
@@ -16,6 +16,7 @@
 
 package edu.usf.cutr.otp.bike_rental.api
 
+import edu.usf.cutr.otp.Api
 import edu.usf.cutr.otp.ApplicationDispatcher
 import edu.usf.cutr.otp.bike_rental.model.Stations
 import io.ktor.client.*
@@ -33,7 +34,7 @@ import kotlinx.serialization.json.Json
 class BikeRentalApi(private val url: String,
                     private val locale: String? = null,
                     private val lowerLeft: String? = null,
-                    private val upperRight: String? = null) {
+                    private val upperRight: String? = null): Api() {
 
     /**
      * Function that fetches Bike Rental information.
@@ -72,6 +73,9 @@ class BikeRentalApi(private val url: String,
         }
         if (upperRight != null) {
             parameters.append("upperRight", upperRight)
+        }
+        if (!apiKeyName.isNullOrEmpty() && !apiKeyValue.isNullOrEmpty()) {
+            parameters.append(apiKeyName, apiKeyValue)
         }
         return parameters
     }

--- a/library/src/commonMain/kotlin/edu/usf/cutr/otp/plan/api/PlanApi.kt
+++ b/library/src/commonMain/kotlin/edu/usf/cutr/otp/plan/api/PlanApi.kt
@@ -16,6 +16,7 @@
 
 package edu.usf.cutr.otp.plan.api
 
+import edu.usf.cutr.otp.Api
 import edu.usf.cutr.otp.ApplicationDispatcher
 import edu.usf.cutr.otp.plan.model.Planner
 import edu.usf.cutr.otp.plan.model.RequestParameters
@@ -32,8 +33,7 @@ import kotlinx.serialization.json.Json
  */
 
 class PlanApi(private val url: String,
-              private val requestParameters: RequestParameters) {
-
+              private val requestParameters: RequestParameters): Api() {
 
     /**
      * Function that fetches Planner resource information.
@@ -42,7 +42,6 @@ class PlanApi(private val url: String,
      */
     fun getPlan(
         success: (Planner) -> Unit, failure: (Throwable?) -> Unit) {
-
         GlobalScope.launch(ApplicationDispatcher) {
             try {
                 val parameters = buildParameters(requestParameters)
@@ -57,6 +56,7 @@ class PlanApi(private val url: String,
             }
         }
     }
+
     /**
      * Function to build the parameter values that is appended to the URL above
      * @param requestParameters - A RequestParameters.kt object to be appended with the URL.
@@ -112,6 +112,9 @@ class PlanApi(private val url: String,
         }
         if (requestParameters.unpreferredRoutes != null) {
             parameters.append("unpreferredRoutes", requestParameters.unpreferredRoutes.toString())
+        }
+        if (!apiKeyName.isNullOrEmpty() && !apiKeyValue.isNullOrEmpty()) {
+            parameters.append(apiKeyName, apiKeyValue)
         }
         return parameters
     }

--- a/library/src/commonMain/kotlin/edu/usf/cutr/otp/serverinfo/api/ServerInfoApi.kt
+++ b/library/src/commonMain/kotlin/edu/usf/cutr/otp/serverinfo/api/ServerInfoApi.kt
@@ -1,5 +1,6 @@
 package edu.usf.cutr.otp.serverinfo.api
 
+import edu.usf.cutr.otp.Api
 import edu.usf.cutr.otp.ApplicationDispatcher
 import edu.usf.cutr.otp.serverinfo.model.ServerInfo
 import io.ktor.client.*
@@ -13,7 +14,7 @@ import kotlinx.serialization.json.Json
  * Manager Class to make HTTP requests to the OTP Server Info API
  * @param url - Full url to the Server info API, Ex: "https://10.0.2.2:8080/otp"
  */
-class ServerInfoApi (private val url: String) {
+class ServerInfoApi (private val url: String): Api() {
 
     /**
      * Function that fetches Server information.
@@ -26,7 +27,12 @@ class ServerInfoApi (private val url: String) {
 
         GlobalScope.launch(ApplicationDispatcher) {
             try {
+                val parameters = ParametersBuilder()
+                if (!apiKeyName.isNullOrEmpty() && !apiKeyValue.isNullOrEmpty()) {
+                    parameters.append(apiKeyName, apiKeyValue)
+                }
                 val url = URLBuilder(
+                    parameters = parameters,
                 ).takeFrom(url).build()
 
                 val json = HttpClient().get<String>(url)


### PR DESCRIPTION
Closes #10

It adds a superclass to hold the basic API key info that's repeated across APIs.

@BumbleFlash Could you please test this as well?

Please feel free to improve on it as you can, but it should be a good start (and maybe completion?) to the API key feature.