### PR TITLE
fix: fix test JSON URLs

### DIFF
--- a/library/src/androidTest/kotlin/edu/usf/cutr/otp/chicago/BikeRentalApiUnitTest.kt
+++ b/library/src/androidTest/kotlin/edu/usf/cutr/otp/chicago/BikeRentalApiUnitTest.kt
@@ -11,7 +11,7 @@ class BikeRentalApiUnitTest {
     @Test
     fun testBikeRentalApi() {
         val bikeRentalApi =
-            BikeRentalApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/chicago/bike_rental.json")
+            BikeRentalApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/chicago/bike_rental.json")
         var s0: Station? = Station()
         var s1: Station? = Station()
         val latch = CountDownLatch(1)

--- a/library/src/androidTest/kotlin/edu/usf/cutr/otp/chicago/PlanApiUnitTest.kt
+++ b/library/src/androidTest/kotlin/edu/usf/cutr/otp/chicago/PlanApiUnitTest.kt
@@ -13,7 +13,7 @@ class PlanApiUnitTest {
     fun testPlanApi() {
         val planApi =
             PlanApi(
-                "https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/chicago/plan.json",
+                "https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/chicago/plan.json",
                 RequestParameters()
             )
         var planner = Planner()

--- a/library/src/androidTest/kotlin/edu/usf/cutr/otp/chicago/ServerInfoApiUnitTest.kt
+++ b/library/src/androidTest/kotlin/edu/usf/cutr/otp/chicago/ServerInfoApiUnitTest.kt
@@ -10,7 +10,7 @@ class ServerInfoApiUnitTest {
     @Test
     fun testServerInfoApi() {
         val serverInfoApi =
-            ServerInfoApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/chicago/server_info.json")
+            ServerInfoApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/chicago/server_info.json")
 
         var serverInfo = ServerInfo()
         val latch = CountDownLatch(1)

--- a/library/src/androidTest/kotlin/edu/usf/cutr/otp/tampa/BikeRentalApiUnitTest.kt
+++ b/library/src/androidTest/kotlin/edu/usf/cutr/otp/tampa/BikeRentalApiUnitTest.kt
@@ -11,7 +11,7 @@ class BikeRentalApiUnitTest {
     @Test
     fun testBikeRentalApi() {
         val bikeRentalApi =
-            BikeRentalApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/tampa/bike_rental.json")
+            BikeRentalApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/tampa/bike_rental.json")
         var s0: Station? = Station()
         var s1: Station? = Station()
         val latch = CountDownLatch(1)

--- a/library/src/androidTest/kotlin/edu/usf/cutr/otp/tampa/PlanApiUnitTest.kt
+++ b/library/src/androidTest/kotlin/edu/usf/cutr/otp/tampa/PlanApiUnitTest.kt
@@ -13,7 +13,7 @@ class PlanApiUnitTest {
     fun testPlanApi() {
         val planApi =
             PlanApi(
-                "https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/tampa/plan.json",
+                "https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/tampa/plan.json",
                 RequestParameters()
             )
         var planner = Planner()

--- a/library/src/androidTest/kotlin/edu/usf/cutr/otp/tampa/ServerInfoApiUnitTest.kt
+++ b/library/src/androidTest/kotlin/edu/usf/cutr/otp/tampa/ServerInfoApiUnitTest.kt
@@ -11,7 +11,7 @@ class ServerInfoApiUnitTest {
     @Test
     fun testServerInfoApi() {
         val serverInfoApi =
-            ServerInfoApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/tampa/server_info.json")
+            ServerInfoApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/tampa/server_info.json")
 
         var serverInfo = ServerInfo()
         val latch = CountDownLatch(1)

--- a/library/src/jvmTest/kotlin/edu/usf/cutr/otp/chicago/BikeRentalApiUnitTest.kt
+++ b/library/src/jvmTest/kotlin/edu/usf/cutr/otp/chicago/BikeRentalApiUnitTest.kt
@@ -11,7 +11,7 @@ class BikeRentalApiUnitTest {
     @Test
     fun testBikeRentalApi() {
         val bikeRentalApi =
-            BikeRentalApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/chicago/bike_rental.json")
+            BikeRentalApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/chicago/bike_rental.json")
         var s0: Station? = Station()
         var s1: Station? = Station()
         val latch = CountDownLatch(1)

--- a/library/src/jvmTest/kotlin/edu/usf/cutr/otp/chicago/PlanApiUnitTest.kt
+++ b/library/src/jvmTest/kotlin/edu/usf/cutr/otp/chicago/PlanApiUnitTest.kt
@@ -13,7 +13,7 @@ class PlanApiUnitTest {
     fun testPlanApi() {
         val planApi =
             PlanApi(
-                "https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/chicago/plan.json",
+                "https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/chicago/plan.json",
                 RequestParameters()
             )
         var planner = Planner()

--- a/library/src/jvmTest/kotlin/edu/usf/cutr/otp/chicago/ServerInfoApiUnitTest.kt
+++ b/library/src/jvmTest/kotlin/edu/usf/cutr/otp/chicago/ServerInfoApiUnitTest.kt
@@ -10,7 +10,7 @@ class ServerInfoApiUnitTest {
     @Test
     fun testServerInfoApi() {
         val serverInfoApi =
-            ServerInfoApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/chicago/server_info.json")
+            ServerInfoApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/chicago/server_info.json")
 
         var serverInfo = ServerInfo()
         val latch = CountDownLatch(1)

--- a/library/src/jvmTest/kotlin/edu/usf/cutr/otp/tampa/BikeRentalApiUnitTest.kt
+++ b/library/src/jvmTest/kotlin/edu/usf/cutr/otp/tampa/BikeRentalApiUnitTest.kt
@@ -11,7 +11,7 @@ class BikeRentalApiUnitTest {
     @Test
     fun testBikeRentalApi() {
         val bikeRentalApi =
-            BikeRentalApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/tampa/bike_rental.json")
+            BikeRentalApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/tampa/bike_rental.json")
         var s0: Station? = Station()
         var s1: Station? = Station()
         val latch = CountDownLatch(1)

--- a/library/src/jvmTest/kotlin/edu/usf/cutr/otp/tampa/PlanApiUnitTest.kt
+++ b/library/src/jvmTest/kotlin/edu/usf/cutr/otp/tampa/PlanApiUnitTest.kt
@@ -13,7 +13,7 @@ class PlanApiUnitTest {
     fun testPlanApi() {
         val planApi =
             PlanApi(
-                "https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/tampa/plan.json",
+                "https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/tampa/plan.json",
                 RequestParameters()
             )
         var planner = Planner()

--- a/library/src/jvmTest/kotlin/edu/usf/cutr/otp/tampa/ServerInfoApiUnitTest.kt
+++ b/library/src/jvmTest/kotlin/edu/usf/cutr/otp/tampa/ServerInfoApiUnitTest.kt
@@ -11,7 +11,7 @@ class ServerInfoApiUnitTest {
     @Test
     fun testServerInfoApi() {
         val serverInfoApi =
-            ServerInfoApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/tests/library/src/jvmTest/resources/tampa/server_info.json")
+            ServerInfoApi("https://raw.githubusercontent.com/CUTR-at-USF/opentripplanner-client-library/main/library/src/jvmTest/resources/tampa/server_info.json")
 
         var serverInfo = ServerInfo()
         val latch = CountDownLatch(1)


### PR DESCRIPTION
PR to switch `tests` to `main` in the test URLs.

Follow up after merging https://github.com/CUTR-at-USF/opentripplanner-client-library/pull/11